### PR TITLE
fixed bug where stylesheet wasn't find

### DIFF
--- a/src/styles.sass
+++ b/src/styles.sass
@@ -18,4 +18,4 @@ $darkest: rgb(18, 16, 22)
 
 
 /* Importing Bootstrap SCSS file. */
-@import '~bootstrap/scss/bootstrap'
+@import "../node_modules/bootstrap/scss/bootstrap"


### PR DESCRIPTION
Bei mir hatte das die ganze Zeit nicht funktioniert. Ich habe dann den Node Ordner gelöscht und npm install durchgeführt. Dann waren die meisten Fehler behoben, danach habe ich in der styles.sass noch den Pfad zu bootstrap geändert, weil da der Fehler lag. Danach hat alles funktioniert.